### PR TITLE
sketch out candid binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,18 @@ A template for using Elm to develop frontend user interface for the Internet Com
 Elm --> JSON --> JS Candid Encoder --> IC canister --> JS Candid Decoder --> JSON --> Elm
 
 Currently Candid methods is untyped to Elm. The error only happens on the JS side in the runtime.
+Eventually, we want to generate method bindings in Elm via the Candid compiler.
+
+# Design choices
+
+There are several options for the `port` function type in Elm:
+
+* JSON value: It's the recommended way for Elm-JS interop. To transfer JS objects, mainly BigNumber and CanisterId, we need to convert objects/classes into a JSON representation, which can be done via the visitor pattern. The downside is that Elm needs to understand the JS specific representation of the Candid values. We can provide a codegen from candid file to hide the representation detail from the user.
+* Variant type: JS doesn't have variant types, and Elm cannot transfer native variant types directly. So we need to design a JSON encoding for variant types, which requires work in both JS and Elm.
+* String (Candid text format): This is language agnostic, and we can build a library for parsing and stringify the Candid values completely in Elm. On the JS side, there is little work required. Conceptually, this is better than JSON, as the format is in the spec and language agnostic, but it requires more work in Elm.
+* Blob (Candid binary format): Also language agnostic, but a bit heavy weight (building type tables, skipping unused fields, etc), and we don't get any code reuse from the JS library.
+
+Overall, it seems the easiest approach is to use JSON for Elm-JS interop.
 
 # Usage 
 

--- a/elm.json
+++ b/elm.json
@@ -6,15 +6,20 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
+            "cmditch/elm-bigint": "2.0.1",
             "elm/browser": "1.0.2",
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
             "elm/json": "1.1.3"
         },
         "indirect": {
+            "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.2",
+            "elm-community/list-extra": "8.2.4",
+            "elm-community/maybe-extra": "5.2.0",
+            "rtfeldman/elm-hex": "1.0.0"
         }
     },
     "test-dependencies": {

--- a/elm.json
+++ b/elm.json
@@ -6,20 +6,15 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "cmditch/elm-bigint": "2.0.1",
             "elm/browser": "1.0.2",
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
             "elm/json": "1.1.3"
         },
         "indirect": {
-            "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.2",
-            "elm-community/list-extra": "8.2.4",
-            "elm-community/maybe-extra": "5.2.0",
-            "rtfeldman/elm-hex": "1.0.0"
+            "elm/virtual-dom": "1.0.2"
         }
     },
     "test-dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,9 @@
   "requires": true,
   "dependencies": {
     "@dfinity/agent": {
-      "version": "0.5.14",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.5.14.tgz",
-      "integrity": "sha512-4zIwZAwauRp4QOFEXwcEjMygcSn+k6+Xp1I00JIBP5h8a34qsEM4H2Vu5rI+Nhyf/aPTfUeMUQQNaWMr8I4iwQ==",
-      "dev": true,
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.6.1.tgz",
+      "integrity": "sha512-UZxxVrdo0kyfbNW5RCENhtWLKf8XMfnE4AN002gzfOR6GoJmiIZKTllO4IV6bINfPcj4/UQGGEvNe0P1Yq0Vvg==",
       "requires": {
         "base64-js": "1.3.1",
         "bignumber.js": "^9.0.0",
@@ -434,8 +433,7 @@
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-      "dev": true
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "big.js": {
       "version": "5.2.2",
@@ -480,7 +478,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
       "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
-      "dev": true,
       "requires": {
         "bignumber.js": "^9.0.0",
         "buffer": "^5.5.0",
@@ -620,7 +617,6 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
       "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-      "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
@@ -636,7 +632,6 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/buffer-pipe/-/buffer-pipe-0.0.4.tgz",
       "integrity": "sha512-8cHio1V6wgX+LIX6+af4tCn0+Ljl2vQd9JZdZ8vDJZdDf8x5p2DneKaq1dWxSswJG+sK4Inok9aqoqILG5kQVQ==",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.1.2"
       }
@@ -887,8 +882,7 @@
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -993,7 +987,6 @@
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
       "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
-      "dev": true,
       "requires": {
         "buffer": "^5.1.0"
       }
@@ -1144,8 +1137,7 @@
     "delimit-stream": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs=",
-      "dev": true
+      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
     },
     "des.js": {
       "version": "1.0.1",
@@ -2016,8 +2008,7 @@
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-      "dev": true
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "iferr": {
       "version": "0.1.5",
@@ -2304,8 +2295,7 @@
     "iso-url": {
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
-      "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==",
-      "dev": true
+      "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog=="
     },
     "isobject": {
       "version": "3.0.1",
@@ -2338,7 +2328,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
       "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
-      "dev": true,
       "requires": {
         "delimit-stream": "0.1.0"
       }
@@ -3345,7 +3334,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -3489,8 +3477,7 @@
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -3588,8 +3575,7 @@
     "simple-cbor": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/simple-cbor/-/simple-cbor-0.4.0.tgz",
-      "integrity": "sha512-2oeucfnjm6V3ngHLQuWSy6QT5dRtma5xZzTa5g+OLz6mlJGoxzE6fe+OT1fRwmpdHAapPm+o7PTiRNJpUuTgQA==",
-      "dev": true
+      "integrity": "sha512-2oeucfnjm6V3ngHLQuWSy6QT5dRtma5xZzTa5g+OLz6mlJGoxzE6fe+OT1fRwmpdHAapPm+o7PTiRNJpUuTgQA=="
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -3930,7 +3916,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       }
@@ -4121,8 +4106,7 @@
     "tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "dev": true
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "typedarray": {
       "version": "0.0.6",
@@ -4265,8 +4249,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "v8-compile-cache": {
       "version": "2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -445,8 +445,7 @@
     "bignumber.js": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
-      "dev": true
+      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
     },
     "binary-extensions": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "webpack-cli": "3.3.10"
   },
   "dependencies": {
+    "bignumber.js": "^9.0.0",
     "elm-webpack-loader": "^6.0.1",
     "file-loader": "^6.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
     "build": "webpack"
   },
   "devDependencies": {
-    "@dfinity/agent": "0.5.14",
     "terser-webpack-plugin": "2.2.2",
     "webpack": "4.41.3",
     "webpack-cli": "3.3.10"
   },
   "dependencies": {
+    "@dfinity/agent": "^0.6.1",
     "bignumber.js": "^9.0.0",
     "elm-webpack-loader": "^6.0.1",
     "file-loader": "^6.0.0"

--- a/src/elm_assets/public/Candid.elm
+++ b/src/elm_assets/public/Candid.elm
@@ -2,7 +2,6 @@ port module Candid exposing (..)
 
 import Json.Encode as E
 import Json.Decode as D
-import BigInt exposing (BigInt)
 
 port sendMessage : (String, List E.Value) -> Cmd msg
 port messageReceiver : ((String, E.Value) -> msg) -> Sub msg
@@ -10,34 +9,8 @@ port messageError : ((String, E.Value) -> msg) -> Sub msg
 
 type alias Principal = String
 
-bigint : D.Decoder BigInt
-bigint = D.string |> D.andThen bigintHelper
-bigintHelper str =
-    case BigInt.fromIntString str of
-        Just num -> D.succeed num
-        Nothing -> D.fail "not bigint"
-
-encodeBigInt n = BigInt.toString n |> E.string
-
 greet : String -> Cmd msg
 greet name = sendMessage("greet", [E.string name])
-fib : BigInt -> Cmd msg
-fib n = sendMessage("fib", [encodeBigInt n])
-getCaller () = sendMessage("getCaller", [])
 
-type ReturnValue = Greet String | Fib BigInt | GetCaller (Principal, Int) | Error_ String
-
-toString val =
-    case val of
-        Greet str -> str
-        Fib int -> BigInt.toString int
-        GetCaller (id, word) -> id ++ ", " ++ String.fromInt word
-        Error_ err -> err
-
-greetDecoder = D.index 0 D.string |> D.map Greet
-fibDecoder = D.index 0 bigint |> D.map Fib
-callerDecoder = D.map2 Tuple.pair (D.index 0 D.string) (D.index 1 D.int) |> D.map GetCaller
-decode decoder msg =
-    case D.decodeValue decoder msg of
-        Ok v -> toString v
-        Err err -> D.errorToString err
+greetDecoder : D.Decoder String
+greetDecoder = D.index 0 D.string

--- a/src/elm_assets/public/Candid.elm
+++ b/src/elm_assets/public/Candid.elm
@@ -18,6 +18,6 @@ fibDecoder = D.index 0 D.string
 callerDecoder = D.map2 Tuple.pair (D.index 0 D.string) (D.index 1 D.int)
 decode decoder msg =
     case D.decodeValue decoder msg of
-        --Ok (id, word) -> "(" ++ id ++ ", " ++ String.fromInt word ++ ")"
-        Ok str -> str
+        Ok (id, word) -> "(" ++ id ++ ", " ++ String.fromInt word ++ ")"
+        --Ok str -> str
         Err err -> D.errorToString err

--- a/src/elm_assets/public/Candid.elm
+++ b/src/elm_assets/public/Candid.elm
@@ -2,22 +2,42 @@ port module Candid exposing (..)
 
 import Json.Encode as E
 import Json.Decode as D
+import BigInt exposing (BigInt)
 
 port sendMessage : (String, List E.Value) -> Cmd msg
 port messageReceiver : ((String, E.Value) -> msg) -> Sub msg
 port messageError : ((String, E.Value) -> msg) -> Sub msg
 
+type alias Principal = String
+
+bigint : D.Decoder BigInt
+bigint = D.string |> D.andThen bigintHelper
+bigintHelper str =
+    case BigInt.fromIntString str of
+        Just num -> D.succeed num
+        Nothing -> D.fail "not bigint"
+
+encodeBigInt n = BigInt.toString n |> E.string
+
 greet : String -> Cmd msg
 greet name = sendMessage("greet", [E.string name])
-fib : String -> Cmd msg
-fib n = sendMessage("fib", [E.string n])
+fib : BigInt -> Cmd msg
+fib n = sendMessage("fib", [encodeBigInt n])
 getCaller () = sendMessage("getCaller", [])
 
-greetDecoder = D.index 0 D.string
-fibDecoder = D.index 0 D.string
-callerDecoder = D.map2 Tuple.pair (D.index 0 D.string) (D.index 1 D.int)
+type ReturnValue = Greet String | Fib BigInt | GetCaller (Principal, Int) | Error_ String
+
+toString val =
+    case val of
+        Greet str -> str
+        Fib int -> BigInt.toString int
+        GetCaller (id, word) -> id ++ ", " ++ String.fromInt word
+        Error_ err -> err
+
+greetDecoder = D.index 0 D.string |> D.map Greet
+fibDecoder = D.index 0 bigint |> D.map Fib
+callerDecoder = D.map2 Tuple.pair (D.index 0 D.string) (D.index 1 D.int) |> D.map GetCaller
 decode decoder msg =
     case D.decodeValue decoder msg of
-        Ok (id, word) -> "(" ++ id ++ ", " ++ String.fromInt word ++ ")"
-        --Ok str -> str
+        Ok v -> toString v
         Err err -> D.errorToString err

--- a/src/elm_assets/public/Candid.elm
+++ b/src/elm_assets/public/Candid.elm
@@ -1,0 +1,23 @@
+port module Candid exposing (..)
+
+import Json.Encode as E
+import Json.Decode as D
+
+port sendMessage : (String, List E.Value) -> Cmd msg
+port messageReceiver : ((String, E.Value) -> msg) -> Sub msg
+port messageError : ((String, E.Value) -> msg) -> Sub msg
+
+greet : String -> Cmd msg
+greet name = sendMessage("greet", [E.string name])
+fib : String -> Cmd msg
+fib n = sendMessage("fib", [E.string n])
+getCaller () = sendMessage("getCaller", [])
+
+greetDecoder = D.index 0 D.string
+fibDecoder = D.index 0 D.string
+callerDecoder = D.map2 Tuple.pair (D.index 0 D.string) (D.index 1 D.int)
+decode decoder msg =
+    case D.decodeValue decoder msg of
+        --Ok (id, word) -> "(" ++ id ++ ", " ++ String.fromInt word ++ ")"
+        Ok str -> str
+        Err err -> D.errorToString err

--- a/src/elm_assets/public/Main.elm
+++ b/src/elm_assets/public/Main.elm
@@ -1,36 +1,17 @@
-port module Main exposing (..)
+module Main exposing (..)
 
 import Browser
+import Candid
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 import Json.Encode as E
-import Json.Decode as D
 
 main =
   Browser.element { init = init, update = update, view = view, subscriptions = subscriptions }
 
-port sendMessage : (String, List E.Value) -> Cmd msg
-port messageReceiver : ((String, E.Value) -> msg) -> Sub msg
-port messageError : ((String, E.Value) -> msg) -> Sub msg
-
-greet : String -> Cmd msg
-greet name = sendMessage("greet", [E.string name])
-fib : String -> Cmd msg
-fib n = sendMessage("fib", [E.string n])
-getCaller () = sendMessage("getCaller", [])
-
-greetDecoder = D.index 0 D.string
-fibDecoder = D.index 0 D.string
-callerDecoder = D.map2 Tuple.pair (D.index 0 D.string) (D.index 1 D.int)
-decode decoder msg =
-    case D.decodeValue decoder msg of
-        --Ok (id, word) -> "(" ++ id ++ ", " ++ String.fromInt word ++ ")"
-        Ok str -> str
-        Err err -> D.errorToString err
-
 subscriptions : Model -> Sub Msg
-subscriptions _ = Sub.batch [messageReceiver Recv, messageError Error]
+subscriptions _ = Sub.batch [Candid.messageReceiver Recv, Candid.messageError Error]
 
 type alias Model = { input : String, output : String }
 
@@ -47,11 +28,11 @@ update msg model =
         ( { model | output = "Waiting..." }
         --, greet(model.input)
         --, getCaller()
-        , fib(model.input)
+        , Candid.fib(model.input)
         )
     Recv (method, message) ->
         --let result = E.encode 0 message in
-        let result = decode fibDecoder message in
+        let result = Candid.decode Candid.fibDecoder message in
         ( { model | output = method ++ ": " ++ result }
         , Cmd.none
         )

--- a/src/elm_assets/public/Main.elm
+++ b/src/elm_assets/public/Main.elm
@@ -2,11 +2,11 @@ module Main exposing (..)
 
 import Browser
 import Candid
-import BigInt
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 import Json.Encode as E
+import Json.Decode as D
 
 main =
   Browser.element { init = init, update = update, view = view, subscriptions = subscriptions }
@@ -27,13 +27,13 @@ update msg model =
     Changed input -> ( { model | input = input }, Cmd.none)
     Send ->
         ( { model | output = "Waiting..." }
-        --, Candid.greet(model.input)
-        --, Candid.getCaller()
-        , Candid.fib(BigInt.fromInt <| Maybe.withDefault -1 <| String.toInt <| model.input)
+        , Candid.greet(model.input)
         )
     Recv (method, message) ->
-        --let result = E.encode 0 message in
-        let result = Candid.decode Candid.fibDecoder message in
+        let result = case D.decodeValue Candid.greetDecoder message of
+                Ok str -> str
+                Err err -> D.errorToString err
+        in
         ( { model | output = method ++ ": " ++ result }
         , Cmd.none
         )

--- a/src/elm_assets/public/Main.elm
+++ b/src/elm_assets/public/Main.elm
@@ -26,13 +26,13 @@ update msg model =
     Changed input -> ( { model | input = input }, Cmd.none)
     Send ->
         ( { model | output = "Waiting..." }
-        --, greet(model.input)
-        --, getCaller()
-        , Candid.fib(model.input)
+        --, Candid.greet(model.input)
+        , Candid.getCaller()
+        --, Candid.fib(model.input)
         )
     Recv (method, message) ->
         --let result = E.encode 0 message in
-        let result = Candid.decode Candid.fibDecoder message in
+        let result = Candid.decode Candid.callerDecoder message in
         ( { model | output = method ++ ": " ++ result }
         , Cmd.none
         )

--- a/src/elm_assets/public/Main.elm
+++ b/src/elm_assets/public/Main.elm
@@ -11,17 +11,14 @@ main =
   Browser.element { init = init, update = update, view = view, subscriptions = subscriptions }
 
 port sendMessage : (String, List E.Value) -> Cmd msg
-port messageReceiver : ((String, String) -> msg) -> Sub msg
+port messageReceiver : ((String, List E.Value) -> msg) -> Sub msg
 port messageError : ((String, E.Value) -> msg) -> Sub msg
 
 greet : String -> Cmd msg
 greet name = sendMessage("greet", [E.string name])
-greetDecoder : E.Value -> String
-greetDecoder val = Result.withDefault "" (D.decodeValue D.string val)
-fib : Int -> Cmd msg                   
+fib : Int -> Cmd msg
 fib n = sendMessage("fib", [E.int n])
-fibDecoder : E.Value -> Int
-fibDecoder val = Result.withDefault -1 (D.decodeValue D.int val)
+getCaller () = sendMessage("getCaller", [])
 
 subscriptions : Model -> Sub Msg
 subscriptions _ = Sub.batch [messageReceiver Recv, messageError Error]
@@ -31,7 +28,7 @@ type alias Model = { input : String, output : String }
 init : () -> (Model, Cmd msg)
 init _ = (Model "" "", Cmd.none)
 
-type Msg = Send | Recv (String, String) | Changed String | Error (String, E.Value)
+type Msg = Send | Recv (String, List E.Value) | Changed String | Error (String, E.Value)
 
 update : Msg -> Model -> (Model, Cmd Msg)
 update msg model =
@@ -39,17 +36,13 @@ update msg model =
     Changed input -> ( { model | input = input }, Cmd.none)
     Send ->
         ( { model | output = "Waiting..." }
-        --, sendMessage ("getCaller", [])
-        --, sendMessage ("fib", [E.int (Maybe.withDefault 0 (String.toInt model.input))])
-        --, sendMessage ("greet", [E.string model.input])
         --, greet(model.input)
-        , fib(Maybe.withDefault 0 (String.toInt model.input))
+        --, fib(Maybe.withDefault 0 (String.toInt model.input))
+        , getCaller()
         )
     Recv (method, message) ->
-        --let result = E.encode 0 message in 
-        --let result = String.fromInt (fibDecoder message) in
-        --let result = greetDecoder message in
-        ( { model | output = method ++ ": " ++ message }
+        let result = List.map (E.encode 0) message |> String.join ", " in
+        ( { model | output = method ++ ": " ++ result }
         , Cmd.none
         )
     Error (method, message) ->

--- a/src/elm_assets/public/Main.elm
+++ b/src/elm_assets/public/Main.elm
@@ -2,6 +2,7 @@ module Main exposing (..)
 
 import Browser
 import Candid
+import BigInt
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
@@ -27,12 +28,12 @@ update msg model =
     Send ->
         ( { model | output = "Waiting..." }
         --, Candid.greet(model.input)
-        , Candid.getCaller()
-        --, Candid.fib(model.input)
+        --, Candid.getCaller()
+        , Candid.fib(BigInt.fromInt <| Maybe.withDefault -1 <| String.toInt <| model.input)
         )
     Recv (method, message) ->
         --let result = E.encode 0 message in
-        let result = Candid.decode Candid.callerDecoder message in
+        let result = Candid.decode Candid.fibDecoder message in
         ( { model | output = method ++ ": " ++ result }
         , Cmd.none
         )

--- a/src/elm_assets/public/Main.elm
+++ b/src/elm_assets/public/Main.elm
@@ -11,7 +11,7 @@ main =
   Browser.element { init = init, update = update, view = view, subscriptions = subscriptions }
 
 port sendMessage : (String, List E.Value) -> Cmd msg
-port messageReceiver : ((String, E.Value) -> msg) -> Sub msg
+port messageReceiver : ((String, String) -> msg) -> Sub msg
 port messageError : ((String, E.Value) -> msg) -> Sub msg
 
 greet : String -> Cmd msg
@@ -31,7 +31,7 @@ type alias Model = { input : String, output : String }
 init : () -> (Model, Cmd msg)
 init _ = (Model "" "", Cmd.none)
 
-type Msg = Send | Recv (String, E.Value) | Changed String | Error (String, E.Value)
+type Msg = Send | Recv (String, String) | Changed String | Error (String, E.Value)
 
 update : Msg -> Model -> (Model, Cmd Msg)
 update msg model =
@@ -46,10 +46,10 @@ update msg model =
         , fib(Maybe.withDefault 0 (String.toInt model.input))
         )
     Recv (method, message) ->
-        --let result = String.join ", " (List.map (\v -> E.encode 0 v) message) in
+        --let result = E.encode 0 message in 
         --let result = String.fromInt (fibDecoder message) in
-        let result = E.encode 0 message in
-        ( { model | output = method ++ ": " ++ result }
+        --let result = greetDecoder message in
+        ( { model | output = method ++ ": " ++ message }
         , Cmd.none
         )
     Error (method, message) ->

--- a/src/elm_assets/public/Main.elm
+++ b/src/elm_assets/public/Main.elm
@@ -11,17 +11,27 @@ main =
   Browser.element { init = init, update = update, view = view, subscriptions = subscriptions }
 
 port sendMessage : (String, List E.Value) -> Cmd msg
-port messageReceiver : ((String, List E.Value) -> msg) -> Sub msg
+port messageReceiver : ((String, E.Value) -> msg) -> Sub msg
+port messageError : ((String, E.Value) -> msg) -> Sub msg
+
+greet : String -> Cmd msg
+greet name = sendMessage("greet", [E.string name])
+greetDecoder : E.Value -> String
+greetDecoder val = Result.withDefault "" (D.decodeValue D.string val)
+fib : Int -> Cmd msg                   
+fib n = sendMessage("fib", [E.int n])
+fibDecoder : E.Value -> Int
+fibDecoder val = Result.withDefault -1 (D.decodeValue D.int val)
 
 subscriptions : Model -> Sub Msg
-subscriptions _ = messageReceiver Recv
+subscriptions _ = Sub.batch [messageReceiver Recv, messageError Error]
 
 type alias Model = { input : String, output : String }
 
 init : () -> (Model, Cmd msg)
 init _ = (Model "" "", Cmd.none)
 
-type Msg = Send | Recv (String, List E.Value) | Changed String
+type Msg = Send | Recv (String, E.Value) | Changed String | Error (String, E.Value)
 
 update : Msg -> Model -> (Model, Cmd Msg)
 update msg model =
@@ -31,11 +41,20 @@ update msg model =
         ( { model | output = "Waiting..." }
         --, sendMessage ("getCaller", [])
         --, sendMessage ("fib", [E.int (Maybe.withDefault 0 (String.toInt model.input))])
-        , sendMessage ("greet", [E.string model.input])
+        --, sendMessage ("greet", [E.string model.input])
+        --, greet(model.input)
+        , fib(Maybe.withDefault 0 (String.toInt model.input))
         )
     Recv (method, message) ->
-        let result = String.join ", " (List.map (\v -> E.encode 0 v) message) in
+        --let result = String.join ", " (List.map (\v -> E.encode 0 v) message) in
+        --let result = String.fromInt (fibDecoder message) in
+        let result = E.encode 0 message in
         ( { model | output = method ++ ": " ++ result }
+        , Cmd.none
+        )
+    Error (method, message) ->
+        let error = E.encode 0 message in
+        ( { model | output = method ++ ": " ++ error }
         , Cmd.none
         )
 

--- a/src/elm_assets/public/candidUtils.js
+++ b/src/elm_assets/public/candidUtils.js
@@ -1,0 +1,99 @@
+import BigNumber from 'bignumber.js';
+import { IDL, CanisterId } from '@dfinity/agent';
+
+export function normalizeReturn(types, res) {
+  let result;
+  if (types.length === 0) {
+    result = [];
+  } else if (types.length === 1) {
+    result = [res];
+  } else {
+    result = res;
+  }
+  return result;
+}
+
+
+class CandidWalker extends IDL.Visitor {
+  constructor(toJSON) {
+    super();
+    if (typeof toJSON !== 'boolean') {
+      throw new Error('unknown flag');
+    }
+    this._toJSON = toJSON;
+  }
+  visitPrimitive(t, v) {
+    return v;
+  }
+  visitNumber(t, v) {
+    if (this._toJSON) {
+      return v.toFixed();
+    } else {
+      return new BigNumber(v);
+    }
+  }
+  visitFixedInt(t, v) {
+    if (this._toJSON && t._bits <= 32) {
+        return v;
+    } else {
+      return this.visitNumber(t, v);
+    }
+  }
+  visitFixedNat(t, v) {
+    return this.visitFixedInt(t, v);
+  }
+  visitPrincipal(t, v) {
+    if (this._toJSON) {
+      return v.toText();
+    } else {
+      return canisterId.fromText(v);
+    }
+  }
+  visitService(t, v) {
+    return this.visitPrincipal(t, v);
+  }
+  visitFunc(t, v) {
+    return [this.visitPrincipal(t, v[0]), v[1]];
+  }
+  visitVec(t, ty, v) {
+    return v.map(val => walker(ty, this._toJSON, val));
+  }
+  visitOpt(t, ty, v) {
+    if (v.length === 0) {
+      return v;
+    }
+    return [walker(ty, this._toJSON, v[0])];
+  }
+  visitRecord(t, fields, v) {
+    const res = {};
+    fields.forEach(([key, type], i) => {
+      res[key] = walker(type, this._toJSON, v[key]);
+    });
+    return res;
+  }
+  visitVariant(t, fields, v) {
+    const res = {};
+    const selected = Object.entries(v)[0];
+    fields.forEach(([key, type]) => {
+      if (key === selected[0]) {
+        res[key] = walker(type, this._toJSON, selected[1]);
+        return res;
+      }
+    });
+    throw new Error('bad variant value');
+  }
+  visitRec(t, ty, v) {
+    return walker(ty, this._toJSON, v);
+  }
+}
+
+function walker(t, toJSON, v) {
+  return t.accept(new CandidWalker(toJSON), v);
+}
+
+export function toJSON(t, v) {
+  return walker(t, true, v);
+}
+export function fromJSON(t, v) {
+  return walker(t, false, v);
+}

--- a/src/elm_assets/public/candidUtils.js
+++ b/src/elm_assets/public/candidUtils.js
@@ -13,7 +13,6 @@ export function normalizeReturn(types, res) {
   return result;
 }
 
-
 class CandidWalker extends IDL.Visitor {
   constructor(toJSON) {
     super();

--- a/src/elm_assets/public/index.js
+++ b/src/elm_assets/public/index.js
@@ -88,7 +88,7 @@ const app = Elm.Main.init({
 
 app.ports.sendMessage.subscribe(([method, json_args]) => {
   const func = service[method];
-  const args = json_args.map((arg, i) => fromJson(func.argTypes[i], arg));
+  const args = func.argTypes.map((t, i) => fromJson(t, json_args[i]));
   backend[method](...args)
     .then(res => {
       const result = normalizeReturn(func.retTypes, res);

--- a/src/elm_assets/public/index.js
+++ b/src/elm_assets/public/index.js
@@ -1,10 +1,9 @@
 import backend from 'ic:canisters/backend';
-import candid from 'ic:idl/backend';
-import { IDL } from '@dfinity/agent';
-import { Elm } from './Main.elm';
+import { Actor } from '@dfinity/agent';
 import * as Util from './candidUtils';
+import { Elm } from './Main.elm';
 
-const service = Object.assign(...candid({IDL})._fields.map(([key, val]) => ({[key]: val})));
+const service = Object.assign(...Actor.interfaceOf(backend)._fields.map(([key, val]) => ({[key]: val})));
 
 const app = Elm.Main.init({
   node: document.getElementById('app'),

--- a/src/elm_assets/public/index.js
+++ b/src/elm_assets/public/index.js
@@ -1,106 +1,10 @@
-import BigNumber from 'bignumber.js';
 import backend from 'ic:canisters/backend';
 import candid from 'ic:idl/backend';
-import { IDL, CanisterId } from '@dfinity/agent';
+import { IDL } from '@dfinity/agent';
 import { Elm } from './Main.elm';
+import * as Util from './candidUtils';
 
 const service = Object.assign(...candid({IDL})._fields.map(([key, val]) => ({[key]: val})));
-
-function normalizeReturn(types, res) {
-  let result;
-  if (types.length === 0) {
-    result = [];
-  } else if (types.length === 1) {
-    result = [res];
-  } else {
-    result = res;
-  }
-  return result;
-}
-
-class CandidWalker extends IDL.Visitor {
-  constructor(toJSON) {
-    super();
-    if (typeof toJSON !== 'boolean') {
-      throw new Error('unknown flag');
-    }
-    this._toJSON = toJSON;
-  }
-  visitPrimitive(t, v) {
-    return v;
-  }
-  visitNumber(t, v) {
-    if (this._toJSON) {
-      return v.toFixed();
-    } else {
-      return new BigNumber(v);
-    }
-  }
-  visitFixedInt(t, v) {
-    if (this._toJSON && t._bits <= 32) {
-        return v;
-    } else {
-      return this.visitNumber(t, v);
-    }
-  }
-  visitFixedNat(t, v) {
-    return this.visitFixedInt(t, v);
-  }
-  visitPrincipal(t, v) {
-    if (this._toJSON) {
-      return v.toText();
-    } else {
-      return canisterId.fromText(v);
-    }
-  }
-  visitService(t, v) {
-    return this.visitPrincipal(t, v);
-  }
-  visitFunc(t, v) {
-    return [this.visitPrincipal(t, v[0]), v[1]];
-  }
-  visitVec(t, ty, v) {
-    return v.map(val => walker(ty, this._toJSON, val));
-  }
-  visitOpt(t, ty, v) {
-    if (v.length === 0) {
-      return v;
-    }
-    return [walker(ty, this._toJSON, v[0])];
-  }
-  visitRecord(t, fields, v) {
-    const res = {};
-    fields.forEach(([key, type], i) => {
-      res[key] = walker(type, this._toJSON, v[key]);
-    });
-    return res;
-  }
-  visitVariant(t, fields, v) {
-    const res = {};
-    const selected = Object.entries(v)[0];
-    fields.forEach(([key, type]) => {
-      if (key === selected[0]) {
-        res[key] = walker(type, this._toJSON, selected[1]);
-        return res;
-      }
-    });
-    throw new Error('bad variant value');
-  }
-  visitRec(t, ty, v) {
-    return walker(ty, this._toJSON, v);
-  }
-}
-
-function walker(t, toJSON, v) {
-  return t.accept(new CandidWalker(toJSON), v);
-}
-
-function toJSON(t, v) {
-  return walker(t, true, v);
-}
-function fromJSON(t, v) {
-  return walker(t, false, v);
-}
 
 const app = Elm.Main.init({
   node: document.getElementById('app'),
@@ -108,11 +12,11 @@ const app = Elm.Main.init({
 
 app.ports.sendMessage.subscribe(([method, json_args]) => {
   const func = service[method];
-  const args = func.argTypes.map((t, i) => fromJSON(t, json_args[i]));
+  const args = func.argTypes.map((t, i) => Util.fromJSON(t, json_args[i]));
   backend[method](...args)
     .then(res => {
-      const result = normalizeReturn(func.retTypes, res);
-      const json = func.retTypes.map((t, i) => toJSON(t, result[i]));
+      const result = Util.normalizeReturn(func.retTypes, res);
+      const json = func.retTypes.map((t, i) => Util.toJSON(t, result[i]));
       app.ports.messageReceiver.send([method, json]);
     })
     .catch(error => {

--- a/src/elm_assets/public/index.js
+++ b/src/elm_assets/public/index.js
@@ -37,14 +37,10 @@ class CandidWalker extends IDL.Visitor {
     }
   }
   visitFixedInt(t, v) {
-    if (this._toJSON) {
-      if (t._bits <= 32) {
+    if (this._toJSON && t._bits <= 32) {
         return v;
-      } else {
-        return v.toFixed();
-      }
     } else {
-      return new BigNumber(v);
+      return this.visitNumber(t, v);
     }
   }
   visitFixedNat(t, v) {

--- a/src/elm_assets/public/index.js
+++ b/src/elm_assets/public/index.js
@@ -1,30 +1,17 @@
 import backend from 'ic:canisters/backend';
-import candid from 'ic:idl/backend';
-import { IDL } from '@dfinity/agent';
 import { Elm } from './Main.elm';
-
-const service = Object.assign(...candid({IDL})._fields.map(([key, val]) => ({[key]: val})));
-
-function normalizeReturn(method, res) {
-  const func = service[method];
-  let result;
-  if (func.retTypes.length === 0) {
-    result = [];
-  } else if (func.retTypes.length === 1) {
-    result = [res];
-  } else {
-    result = res;
-  }
-  return result;
-}
 
 const app = Elm.Main.init({
   node: document.getElementById('app'),
 });
 
 app.ports.sendMessage.subscribe(([method, args]) => {
-  backend[method](...args).then(res => {
-    const result = normalizeReturn(method, res);
-    app.ports.messageReceiver.send([method, result]);
-  });
+  backend[method](...args)
+    .then(res => {
+      app.ports.messageReceiver.send([method, res]);
+    })
+    .catch(error => {
+      app.ports.messageError.send([method, error.message]);
+      throw error;
+    });
 });

--- a/src/elm_assets/public/index.js
+++ b/src/elm_assets/public/index.js
@@ -1,5 +1,21 @@
 import backend from 'ic:canisters/backend';
+import candid from 'ic:idl/backend';
+import { IDL } from '@dfinity/agent';
 import { Elm } from './Main.elm';
+
+const service = Object.assign(...candid({IDL})._fields.map(([key, val]) => ({[key]: val})));
+
+function normalizeReturn(types, res) {
+  let result;
+  if (types.length === 0) {
+    result = [];
+  } else if (types.length === 1) {
+    result = [res];
+  } else {
+    result = res;
+  }
+  return result;
+}
 
 const app = Elm.Main.init({
   node: document.getElementById('app'),
@@ -8,7 +24,10 @@ const app = Elm.Main.init({
 app.ports.sendMessage.subscribe(([method, args]) => {
   backend[method](...args)
     .then(res => {
-      app.ports.messageReceiver.send([method, res]);
+      const func = service[method];
+      const result = normalizeReturn(func.retTypes, res);
+      const text = IDL.FuncClass.argsToString(func.retTypes, result);
+      app.ports.messageReceiver.send([method, text]);
     })
     .catch(error => {
       app.ports.messageError.send([method, error.message]);

--- a/src/elm_assets/public/index.js
+++ b/src/elm_assets/public/index.js
@@ -88,6 +88,7 @@ class CandidWalker extends IDL.Visitor {
         return res;
       }
     });
+    throw new Error('bad variant value');
   }
   visitRec(t, ty, v) {
     return walker(ty, this._toJSON, v);


### PR DESCRIPTION
Several options for the port function type:
- JSON value: It's the recommended way for Elm-JS interop. To transfer JS objects, mainly BigNumber and CanisterId, we need to convert objects/classes into a JSON representation, which can be done via the visitor pattern. The downside is that Elm needs to understand the JS specific representation of the Candid values. We can provide a codegen from candid file to hide the representation detail from the user.
- Variant type: JS doesn't have variant types, and Elm cannot transfer native variant types directly. So we need to design a JSON encoding for variant types, which requires work in both JS and Elm.
- String (Candid text format): This is language agnostic, and we can build a library for parsing and stringify the Candid values completely in Elm. On the JS side, there is little work required. Conceptually, this is better than JSON, as the format is in the spec and language agnostic, but it requires more work in Elm.
- Blob (Candid binary format): Also language agnostic, but a bit heavy weight (building type tables, skipping unused fields, etc), and we don't get any code reuse from the JS library.

Overall, it seems the easiest approach is to use JSON for Elm-JS interop.